### PR TITLE
General code fix 1

### DIFF
--- a/build-monitor-acceptance/src/main/java/com/smartcodeltd/aether/ArtifactTransporter.java
+++ b/build-monitor-acceptance/src/main/java/com/smartcodeltd/aether/ArtifactTransporter.java
@@ -1,5 +1,6 @@
 package com.smartcodeltd.aether;
 
+import net.serenitybdd.integration.jenkins.environment.rules.FindFreePort;
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
@@ -16,6 +17,8 @@ import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
 import org.eclipse.aether.spi.connector.transport.TransporterFactory;
 import org.eclipse.aether.transport.file.FileTransporterFactory;
 import org.eclipse.aether.transport.http.HttpTransporterFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.validation.constraints.NotNull;
 import java.nio.file.Path;
@@ -27,8 +30,11 @@ import static java.lang.String.format;
 
 public class ArtifactTransporter {
 
+    private static final Logger Log = LoggerFactory.getLogger(FindFreePort.class);
+
     private final List<RemoteRepository> remoteLocations;
     private final Path localRepositoryLocation;
+
 
     public ArtifactTransporter(Path localRepositoryLocation, RemoteRepository... remoteLocations) {
         this.localRepositoryLocation = localRepositoryLocation;
@@ -58,7 +64,7 @@ public class ArtifactTransporter {
 
             artifact = artifactResult.getArtifact();
 
-            System.out.println(artifact + " resolved to  " + artifact.getFile());
+            Log.info(artifact + " resolved to  " + artifact.getFile());
 
             return artifact.getFile().toPath();
 

--- a/build-monitor-acceptance/src/main/java/com/smartcodeltd/aether/ConsoleTransferListener.java
+++ b/build-monitor-acceptance/src/main/java/com/smartcodeltd/aether/ConsoleTransferListener.java
@@ -33,7 +33,7 @@ public class ConsoleTransferListener
 
     private PrintStream out;
 
-    private Map<TransferResource, Long> downloads = new ConcurrentHashMap<TransferResource, Long>();
+    private Map<TransferResource, Long> downloads = new ConcurrentHashMap<>();
 
     private int lastLength;
 
@@ -102,7 +102,7 @@ public class ConsoleTransferListener
         TransferResource resource = event.getResource();
         long contentLength = event.getTransferredBytes();
         if (contentLength >= 0) {
-            String type = (event.getRequestType() == TransferEvent.RequestType.PUT ? "Uploaded" : "Downloaded");
+            String type = event.getRequestType() == TransferEvent.RequestType.PUT ? "Uploaded" : "Downloaded";
             String len = contentLength >= 1024 ? toKB(contentLength) + " KB" : contentLength + " B";
 
             String throughput = "";

--- a/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/model/ProjectStatus.java
+++ b/build-monitor-acceptance/src/main/java/com/smartcodeltd/jenkinsci/plugins/build_monitor/model/ProjectStatus.java
@@ -56,8 +56,6 @@ public enum ProjectStatus {
     // todo: Java 8?
 
     private static Set<String> projectStatusClasses() {
-        // todo: can I use that instead? EnumValues.forType(ProjectStatus.class);
-
         return setOf(stringRepresentationsOf(EnumSet.allOf(ProjectStatus.class)));
     }
 

--- a/build-monitor-acceptance/src/main/java/com/sonyericsson/jenkins/plugins/bfa/user_interface/FailureCauseManagementPage.java
+++ b/build-monitor-acceptance/src/main/java/com/sonyericsson/jenkins/plugins/bfa/user_interface/FailureCauseManagementPage.java
@@ -7,9 +7,9 @@ import net.serenitybdd.screenplay.targets.Target;
 
 public class FailureCauseManagementPage {
     public static final Target Create_New_Link = Link.called("Create new");
-    public static final Target Name            = Setting.defining("Name"); //Target.the("Name field").locatedBy("//*[@name='_.name']");
-    public static final Target Description     = Setting.defining("Description"); //Target.the("Description field").locatedBy("//*[@name='_.description']");
-    public static final Target Comment         = Setting.defining("Comment"); //Target.the("Comment field").locatedBy("//*[@name='_.comment']");
+    public static final Target Name            = Setting.defining("Name");
+    public static final Target Description     = Setting.defining("Description");
+    public static final Target Comment         = Setting.defining("Comment");
     public static final Target Add_Indication  = Button.called("Add Indication");
 
     public static final Target Build_Log_Indication_Link            = Link.called("Build Log Indication");

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/environment/PluginDescription.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/environment/PluginDescription.java
@@ -1,5 +1,9 @@
 package net.serenitybdd.integration.jenkins.environment;
 
+import net.serenitybdd.integration.jenkins.environment.rules.FindFreePort;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.validation.constraints.NotNull;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -7,9 +11,12 @@ import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 
 public class PluginDescription {
+    private static final Logger Log = LoggerFactory.getLogger(FindFreePort.class);
     public static PluginDescription of(@NotNull Path pluginAtPath) {
+        JarFile jarFile = null;
         try {
-            Attributes attrs = new JarFile(pluginAtPath.toFile()).getManifest().getMainAttributes();
+            jarFile = new JarFile(pluginAtPath.toFile());
+            Attributes attrs = jarFile.getManifest().getMainAttributes();
 
             return new PluginDescription(
                     pluginAtPath,
@@ -20,6 +27,16 @@ public class PluginDescription {
         }
         catch(IOException e) {
             throw new RuntimeException(String.format("Couldn't read the manifest file of '%s'.", pluginAtPath.toAbsolutePath()), e);
+        }
+        finally {
+            if(jarFile!=null){
+                try {
+                    jarFile.close();
+                } catch (IOException e) {
+                    Log.error("error closing jarFile",e);
+                }
+
+            }
         }
     }
 

--- a/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/environment/UpdateCenter.java
+++ b/build-monitor-acceptance/src/main/java/net/serenitybdd/integration/jenkins/environment/UpdateCenter.java
@@ -46,10 +46,17 @@ public class UpdateCenter {
         Path destination = Files.createTempFile(tempDir, "", ".tmp");
 
         ReadableByteChannel rbc = Channels.newChannel(link.openStream());
-        FileOutputStream fos = new FileOutputStream(destination.toAbsolutePath().toFile());
-        fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
+        FileOutputStream fos = null;
+        try{
+            fos = new FileOutputStream(destination.toAbsolutePath().toFile());
+            fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
 
-        return destination;
+            return destination;
+        } finally {
+            if(fos!=null){
+                fos.close();
+            }
+        }
     }
 
     private URL url(String template, String... params) throws MalformedURLException {

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByLastBuildTime.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/order/ByLastBuildTime.java
@@ -29,6 +29,6 @@ public class ByLastBuildTime implements Comparator<Job<?, ?>> {
     	}
 
     	// "New is always better" - B. Stinson ;-)
-        return (b.getLastBuild().getTimestamp().compareTo(a.getLastBuild().getTimestamp()));
+        return b.getLastBuild().getTimestamp().compareTo(a.getLastBuild().getTimestamp());
     }
 }

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/BuildView.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/BuildView.java
@@ -64,7 +64,7 @@ public class BuildView implements BuildViewModel {
     }
 
     private boolean isRunning(Run<?, ?> build) {
-        return (build.hasntStartedYet() || build.isBuilding() || build.isLogUpdated());
+        return build.hasntStartedYet() || build.isBuilding() || build.isLogUpdated();
     }
 
     @Override

--- a/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobView.java
+++ b/build-monitor-plugin/src/main/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobView.java
@@ -196,6 +196,12 @@ public class JobView {
         return Objects.hashCode(job.hashCode());
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        return Objects.equal(job,obj);
+    }
+
+
     public String toString() {
         return name();
     }

--- a/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobViewTest.java
+++ b/build-monitor-plugin/src/test/java/com/smartcodeltd/jenkinsci/plugins/buildmonitor/viewmodel/JobViewTest.java
@@ -274,10 +274,6 @@ public class JobViewTest {
                 a(jobView().of(a(job().whereTheLast(build().isStillBuilding()).andThePrevious(build().finishedWith(SUCCESS))))),
                 a(jobView().of(a(job().whereTheLast(build().isStillUpdatingTheLog()).andThePrevious(build().finishedWith(SUCCESS))))));
 
-        // I could do this instead of having two assertions:
-        // assertThat(view.status(), both(containsString("successful")).and(containsString("running")));
-        // but then it would require Java 7
-
         for (JobView view : views) {
             assertThat(view.status(), containsString("successful"));
             assertThat(view.status(), containsString("running"));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules

squid:S2095 - Resources should be closed.

squid:S1206 - "equals(Object obj)" and "hashCode()" should be overridden in pairs.

squid:S2293 - The diamond operator ("<>") should be used.

squid:S106 - Standard outputs should not be used directly to log anything.

squid:CommentedOutCodeLine - Sections of code should not be "commented out".

squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.

You can find more information about the issues here:
https://dev.eclipse.org/sonar/rules/show/squid:S2095 
https://dev.eclipse.org/sonar/rules/show/squid:S1206
https://dev.eclipse.org/sonar/rules/show/squid:S2293
https://dev.eclipse.org/sonar/rules/show/squid:S106 
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck

Please let me know if you have any questions.

Soso Tughushi